### PR TITLE
Add command to publish routes

### DIFF
--- a/src/Console/Commands/MediablePublishRoutesCommand.php
+++ b/src/Console/Commands/MediablePublishRoutesCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Mabrouk\Mediable\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class MediablePublishRoutesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'mediable:publish-routes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish the routes for the Mediable package';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $routesPublishSubDirectory = config('mediable.routes_publish_subdirectory');
+
+        if (File::exists(base_path("routes/{$routesPublishSubDirectory}mediable_routes.php"))) {
+            $this->info("Routes have already been published in routes/{$routesPublishSubDirectory} directory.");
+            return Command::SUCCESS;
+        }
+
+        File::copy(
+            __DIR__ . "/../../routes/mediable_routes.php",
+            base_path("routes/{$routesPublishSubDirectory}mediable_routes.php")
+        );
+
+        $this->publishConfiguration();
+
+        $this->info('Routes have been published successfully.');
+
+        return Command::SUCCESS;
+    }
+
+    private function publishConfiguration($forcePublish = false)
+    {
+        $params = [
+            '--provider' => 'Mabrouk\Mediable\MediableServiceProvider',
+        ];
+
+        if ($forcePublish === true) {
+            $params['--force'] = true;
+        }
+
+        $this->call('vendor:publish', $params, new \Symfony\Component\Console\Output\NullOutput());
+    }
+}

--- a/src/MediableServiceProvider.php
+++ b/src/MediableServiceProvider.php
@@ -4,6 +4,7 @@ namespace Mabrouk\Mediable;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Mabrouk\Mediable\Console\Commands\MediablePublishRoutesCommand;
 
 class MediableServiceProvider extends ServiceProvider
 {
@@ -27,6 +28,10 @@ class MediableServiceProvider extends ServiceProvider
         require_once __DIR__ . '/Helpers/MediableHelperFunctions.php';
 
         $this->registerRoutes();
+
+        $this->commands([
+            MediablePublishRoutesCommand::class,
+        ]);
 
         if ($this->app->runningInConsole()) {
             /**
@@ -58,9 +63,11 @@ class MediableServiceProvider extends ServiceProvider
 
     protected function registerRoutes()
     {
-        Route::group($this->routeConfiguration(), function () {
-            $this->loadRoutesFrom(__DIR__ . '/routes/mediable_routes.php');
-        });
+        if (config('mediable.load_routes')) {
+            Route::group($this->routeConfiguration(), function () {
+                $this->loadRoutesFrom(__DIR__ . '/routes/mediable_routes.php');
+            });
+        }
     }
 
     protected function routeConfiguration()

--- a/src/config/mediable.php
+++ b/src/config/mediable.php
@@ -34,4 +34,28 @@ return [
     'protected_internal_media_base_paths' => [
         // '' => [],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Routes publish subdirectory
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the subdirectory where the package routes should be
+    | published inside the project's routes folder. This allows you to customize the location of the published
+    | routes files.
+    |
+    */
+    # eg: 'routes_publish_subdirectory' => 'custom/',
+    'routes_publish_subdirectory' => '',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load Routes
+    |--------------------------------------------------------------------------
+    |
+    | This option controls whether the package routes should be loaded.
+    | Set this value to true to load the routes, or false to disable them.
+    |
+    */
+    'load_routes' => true,
 ];


### PR DESCRIPTION
- Changes

1. Add MediablePublishRoutesCommand to publish routes.
2. Add 'routes_publish_subdirectory' to specify routes should be published inside the project's routes folder
3. Add 'load_routes' to enable/disable route registering from service provider